### PR TITLE
feat: support specifying listen host

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 REMNAWAVE_URL=sub_domain
 APP_PORT=4000
+APP_HOST=localhost
 # V2RAY_TEMPLATE_PATH=/app/templates/v2ray/default.json
 # V2RAY_MUX_ENABLED=true
 # V2RAY_MUX_TEMPLATE_PATH=/app/templates/v2ray/mux_default.json

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -26,7 +26,7 @@ func Start(service *service.Service) {
 	r.HandleFunc("/{shortUuid}", userAgentRouter(handler)).Methods("GET")
 
 	Server = &http.Server{
-		Addr:    fmt.Sprintf("%s:%s", "localhost", config.GetConfig().AppPort),
+		Addr:    fmt.Sprintf("%s:%s", config.GetConfig().AppHost, config.GetConfig().AppPort),
 		Handler: r,
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	V2RayMuxTemplate     map[string]interface{}
 	RemnaweveURL         string
 	AppPort              string
+	AppHost              string
 	WebPageTemplatePath  string
 	WebPageTemplate      *template.Template
 	HappJsonEnabled      bool
@@ -86,7 +87,6 @@ func InitConfig() {
 			panic(err)
 		}
 		conf.V2RayMuxTemplate = utils.ConvertJsonStringIntoMap(string(muxData))
-
 	}
 
 	conf.RemnaweveURL = os.Getenv("REMNAWAVE_URL")
@@ -94,6 +94,12 @@ func InitConfig() {
 		slog.Error("remnawave url not found")
 		panic(errors.New("remnawave url not found"))
 	}
+
+	conf.AppHost = os.Getenv("APP_HOST")
+	if conf.AppHost == "" {
+		conf.AppHost = "localhost"
+	}
+
 	conf.AppPort = os.Getenv("APP_PORT")
 	if conf.AppPort == "" {
 		slog.Error("app port not found")

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Modify `.env.sample` to adjust the application settings:
 ```
 REMNAWAVE_URL=sub_domain
 APP_PORT=4000
+APP_HOST=localhost
 # V2RAY_TEMPLATE_PATH=/app/templates/v2ray/default.json
 # V2RAY_MUX_ENABLED=true
 # V2RAY_MUX_TEMPLATE_PATH=/app/templates/v2ray/mux_default.json
@@ -92,27 +93,31 @@ docker compose down && docker compose up -d
    _Description:_ The port on which the application will run.  
    _Example:_ `APP_PORT=4000`
 
-3. **V2RAY_TEMPLATE_PATH**  
+3. **APP_HOST**  
+   _Description:_ The host address on which the application will listen. Use "0.0.0.0" to listen on all available network interfaces.  
+   _Example:_ `APP_HOST=localhost`
+
+4. **V2RAY_TEMPLATE_PATH**  
    _Description:_ The file path to the default V2Ray configuration template.  
    _Example:_ `V2RAY_TEMPLATE_PATH=/app/templates/v2ray/default.json`
 
-4. **V2RAY_MUX_ENABLED**  
+5. **V2RAY_MUX_ENABLED**  
    _Description:_ A flag to enable or disable the V2Ray Mux feature. Set to `true` to enable Mux.  
    _Example:_ `V2RAY_MUX_ENABLED=true`
 
-5. **V2RAY_MUX_TEMPLATE_PATH**  
+6. **V2RAY_MUX_TEMPLATE_PATH**  
    _Description:_ The file path to the V2Ray Mux configuration template.  
    _Example:_ `V2RAY_MUX_TEMPLATE_PATH=/app/templates/v2ray/mux_default.json`
 
-6. **WEB_PAGE_TEMPLATE_PATH**  
+7. **WEB_PAGE_TEMPLATE_PATH**  
    _Description:_ The file path to the subscription template.  
    _Example:_ `WEB_PAGE_TEMPLATE_PATH=/app/templates/subscription/index.html`
 
-7. **HAPP_JSON_ENABLED**  
+8. **HAPP_JSON_ENABLED**  
    _Description:_ A flag to enable or disable JSON output for Happ.  
    _Example:_ `HAPP_JSON_ENABLED=false`
 
-8. **HAPP_ROUTING**  
+9. **HAPP_ROUTING**  
    _Description:_ The routing path for Happ connections.  
    _Example:_ `HAPP_ROUTING=happ://routing/...`
 


### PR DESCRIPTION
# Support specifying listen host

- Adds `APP_HOST` configuration option to allow specifying the network interface the server listens on. 
- Default remains `localhost`, but can be set to `0.0.0.0` to listen on all interfaces. 
- Updates documentation and sample environment file accordingly.